### PR TITLE
Add ability to sort multi-selected tabs specifically

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ https://github.com/user-attachments/assets/fc792843-b1da-448e-ba00-63322a3d9c99
 - The script has two phases, first it manually sorts tabs that have common words in their title and URL, second it uses the AI to sort rest of the tabs and checks if they fit in the existing groups (that were manually created) or if it should create a new group.
 - The script only fetches the tabs full URL and title, thus it prioritizes the title first for main context and URL for sub context.
 - The sort function only works when there is two or more tabs to sort into a group.
-- You can also have a selected group tabs sorted as well, this allows you to have fine grained control over the sorting (works for tabs that are already grouped as well, they may be re-sorted).
+- You can also have a selected group of tabs sorted as well, this allows you to have fine-grained control over the sorting (works for tabs that are already grouped as well, they may be re-sorted).
 - You are free to change the AI prompt to your suitable workflow. The prompt is at the top in `apiConfig`.
 - The `Clear` button only clears un-grouped non-pinned tabs.
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ https://github.com/user-attachments/assets/fc792843-b1da-448e-ba00-63322a3d9c99
 
 ## Pre-requisites
 - Enable userChrome Customizations:
-    In `about:config` go to `toolkit.legacyUserProfileCustomizations.stylesheets` and set it to True.
+    In `about:config` go to `toolkit.legacyUserProfileCustomizations.stylesheets` and set it to `true`.
 - Install and Setup the userChrome.js Loader from [Autoconfig](https://github.com/MrOtherGuy/fx-autoconfig/tree/master)
 - Install the Tab Groups config from [Advanced Tab Groups](https://github.com/Anoms12/Advanced-Tab-Groups)
     If you already have a Tab Groups config you can skip this

--- a/README.md
+++ b/README.md
@@ -1,39 +1,39 @@
-# ✨ Ai Tab Groups for Zen Browser ✨
+# ✨ AI Tab Groups for Zen Browser ✨
 ‼️This is still Work-in-Progress ‼️
 
 https://github.com/user-attachments/assets/fc792843-b1da-448e-ba00-63322a3d9c99
-
 
 ## Pre-requisites
 - Enable userChrome Customizations:
     In `about:config` go to `toolkit.legacyUserProfileCustomizations.stylesheets` and set it to True.
 - Install and Setup the userChrome.js Loader from [Autoconfig](https://github.com/MrOtherGuy/fx-autoconfig/tree/master)
-- Install the Tab groups config from [Advanced Tab Groups](https://github.com/Anoms12/Advanced-Tab-Groups)
-    If you already have a TabGroup Config you can skip this
+- Install the Tab Groups config from [Advanced Tab Groups](https://github.com/Anoms12/Advanced-Tab-Groups)
+    If you already have a Tab Groups config you can skip this
   
 ## Setup and Install
-- Copy and paste the `tab_sort.uc.js` file to your `chrome/JS` folder.
+- Copy and paste the `tab_sort_clear.uc.js` file to your `chrome/JS` folder.
 ### AI Setup
 1. For Gemini (RECOMMENDED)
     - Set `gemini { enabled:true }` in `apiConfig` and `ollama { enabled:false }` in `apiConfig`
-    - Get an API Key from [Ai Studios](https://aistudio.google.com)
-    - Replace `YOUR_GEMINI_API_KEY` with the copied API key
-    - Dont change the gemini model since 2.0 has very low rate limits (unless you are rich ig)
+    - Get an API Key from [AI Studios](https://aistudio.google.com)
+    - Replace `YOUR_GEMINI-API-KEY` with the copied API key
+    - Don't change the Gemini model since 2.0 has very low rate limits (unless you are rich ig)
 2. For Ollama
     - Download and install [Ollama](https://ollama.com/)
-    - Install your prefered model. The script uses  `llama3.1` by default
-    - Set  `ollama { enabled:true }` in `apiConfig` and  `gemini { enabled:false }` in `apiConfig`
+    - Install your preferred model. The script uses `llama3.1` by default
+    - Set `ollama { enabled:true }` in `apiConfig` and `gemini { enabled:false }` in `apiConfig`
     - Set the model you downloaded in ollama.model: in the config (you can see the models by doing `ollama list` in terminal)
-- Make sure `browser.tabs.groups.smart.enabled` is set to `False` in `about:config`
-- Open Zen browser, go to `about:support` and clear start up cache.
+- Make sure `browser.tabs.groups.smart.enabled` is set to `false` in `about:config`
+- Open Zen browser, go to `about:support` and clear the startup cache.
 - Done. Enjoy ^^
 
 ## How it works?
-- The script has two phases, first it manually sorts tabs that have common words in their title and url, second it uses the ai to sort rest of the tab and see if they fit in the existing groups (that were manually created) or should it create a new group.
-- The script only fetches the tabs full url and title, thus it prioritizes the title first for main context and url for sub context.
-- The sort function only works when the cateogry has 2 or more tabs to sort into a group
-- You are free to change the ai prompt to your suitable workflow. The prompt is at the top in `apiConfig`.
-- The Clear button only clears un-grouped nonpinned tabs.
+- The script has two phases, first it manually sorts tabs that have common words in their title and URL, second it uses the AI to sort rest of the tabs and checks if they fit in the existing groups (that were manually created) or if it should create a new group.
+- The script only fetches the tabs full URL and title, thus it prioritizes the title first for main context and URL for sub context.
+- The sort function only works when there is two or more tabs to sort into a group.
+- You can also have a selected group tabs sorted as well, this allows you to have fine grained control over the sorting (works for tabs that are already grouped as well, they may be re-sorted).
+- You are free to change the AI prompt to your suitable workflow. The prompt is at the top in `apiConfig`.
+- The `Clear` button only clears un-grouped non-pinned tabs.
 
 **Peace <3**
 

--- a/tab_sort_clear.uc.js
+++ b/tab_sort_clear.uc.js
@@ -1,4 +1,4 @@
-// FINAL VERSION 4.9.2 (Fixed Existing Group Selector using :has())
+// VERSION 4.10.0 (Added tab multi-selection sort capability)
 (() => {
     // --- Configuration ---
     const CONFIG = {
@@ -658,7 +658,13 @@
             return;
         }
         isSorting = true;
-        console.log("Starting tab sort (v4.9.2 - Fixed Group Selector)...");
+
+        // Check for multiple tab selection
+        const selectedTabs = gBrowser.selectedTabs;
+        const isSortingSelectedTabs = selectedTabs.length > 1;
+        const actionType = isSortingSelectedTabs ? "selected tabs" : "all ungrouped tabs";
+
+        console.log(`Starting tab sort (${actionType} mode) - (v4.10.0 - Flexible Group Selector)...`);
 
         let separatorsToSort = []; // Keep track of separators to remove class later
         try {
@@ -693,26 +699,43 @@
             });
             console.log(`Found ${allExistingGroupNames.size} existing group names for context:`, Array.from(allExistingGroupNames));
 
-            // CORRECTED: Filter initial tabs - ensure they aren't already in a group matched by the NEW selector
-            const initialTabsToSort = Array.from(gBrowser.tabs).filter(tab => {
-                const isInCorrectWorkspace = tab.getAttribute('zen-workspace-id') === currentWorkspaceId;
-                const groupParent = tab.closest('tab-group');
-                const isInGroupInCorrectWorkspace = groupParent ? groupParent.matches(groupSelector) : false;
-
-                return isInCorrectWorkspace &&             // Must be in the target workspace
-                       !tab.pinned &&                     // Not pinned
-                       !tab.hasAttribute('zen-empty-tab') && // Not an empty zen tab
-                       !isInGroupInCorrectWorkspace &&    // Not already in a group belonging to this workspace
-                       tab.isConnected;                   // Tab is connected
-            });
-
+            // Determine if we are sorting multiple selected tabs
+            let initialTabsToSort = [];
+            if (isSortingSelectedTabs) {
+                console.log(` -> Sorting ${selectedTabs.length} selected tabs.`);
+                initialTabsToSort = selectedTabs.filter(tab => {
+                    const isInCorrectWorkspace = tab.getAttribute('zen-workspace-id') === currentWorkspaceId;
+                    // For multi-selected tabs, we allow sorting even if they are already in a group.
+                    return (
+                        isInCorrectWorkspace &&
+                        !tab.pinned &&
+                        !tab.hasAttribute('zen-empty-tab') &&
+                        tab.isConnected
+                    );
+                });
+            } else {
+                // Sort all ungrouped tabs - ensure they aren't already in a group matched by the NEW selector
+                console.log(" -> Sorting all ungrouped tabs in the current workspace.");
+                initialTabsToSort = Array.from(gBrowser.tabs).filter(tab => {
+                    const isInCorrectWorkspace = tab.getAttribute('zen-workspace-id') === currentWorkspaceId;
+                    const groupParent = tab.closest('tab-group');
+                    const isInGroupInCorrectWorkspace = groupParent ? groupParent.matches(groupSelector) : false;
+                    return (
+                        isInCorrectWorkspace &&  // Must be in the target workspace
+                        !tab.pinned && // Not pinned
+                        !tab.hasAttribute('zen-empty-tab') && // Not an empty zen tab
+                        !isInGroupInCorrectWorkspace && // Not already in a group belonging to this workspace
+                        tab.isConnected // Tab is connected
+                    );
+                });
+            }
 
             if (initialTabsToSort.length === 0) {
-                console.log("No ungrouped, connected tabs to sort in this workspace.");
+                console.log(`No tabs to sort in this workspace (${actionType} mode).`);
                 // No need to set isSorting = false here, finally block handles it
                 return; // Exit early
             }
-            console.log(`Found ${initialTabsToSort.length} potentially sortable tabs.`);
+            console.log(`Found ${initialTabsToSort.length} tabs to process for sorting.`);
 
             // --- Pre-Grouping Logic (Keywords & Hostnames) ---
             const preGroups = {};
@@ -941,14 +964,18 @@
 
             // --- Process each final, consolidated group ---
             for (const topic in finalGroups) {
-                // Filter AGAIN for valid, connected tabs NOT ALREADY IN ANY GROUP right before moving/grouping
-                // Check closest group parent *again* before moving
+                // Filter AGAIN for valid, connected tabs
                 const tabsForThisTopic = finalGroups[topic].filter(t => {
+                    if (!t || !t.isConnected) return false;
                     const groupParent = t.closest('tab-group');
-                    // Check if the parent group matches the selector for the *current* workspace
                     const isInGroupInCorrectWorkspace = groupParent ? groupParent.matches(groupSelector) : false;
-                    return t && t.isConnected && !isInGroupInCorrectWorkspace;
-                 });
+                    if (!isSortingSelectedTabs) {
+                        // Only allow ungrouped tabs to be consider when NOT multi-selecting
+                        return !isInGroupInCorrectWorkspace;
+                    }
+                    // If there is multiple tabs selected, allow even if already in a group
+                    return true;
+                });
 
 
                 if (tabsForThisTopic.length === 0) {
@@ -1143,7 +1170,7 @@
         if (!container.querySelector('#sort-button')) {
             try {
                 const buttonFragment = window.MozXULElement.parseXULToFragment(
-                    `<toolbarbutton id="sort-button" command="cmd_zenSortTabs" label="⇄ Sort" tooltiptext="Sort Tabs into Groups by Topic (AI)"/>`
+                    `<toolbarbutton id="sort-button" command="cmd_zenSortTabs" label="⇅ Sort" tooltiptext="Sort Tabs into Groups by Topic (AI)"/>`
                 );
                 container.appendChild(buttonFragment.firstChild.cloneNode(true));
                 console.log("BUTTONS: Sort button added to container:", container.id || container.className);
@@ -1284,7 +1311,7 @@
     // --- Initial Setup Trigger ---
 
     function initializeScript() {
-        console.log("INIT: Sort & Clear Tabs Script (v4.9.2 - Gemini - Structured) loading...");
+        console.log("INIT: Sort & Clear Tabs Script (v4.10.0 - Gemini - Structured) loading...");
         let checkCount = 0;
         const maxChecks = 30; // Check for up to ~30 seconds
         const checkInterval = 1000; // Check every second


### PR DESCRIPTION
Closes #9 

- Add functionality to sort multi-selected tabs (also allows possible re-sorting of multi-selected tabs that are already grouped)

Previously existing sorting functionality should remain working in all conditions like before, feel free to go over this and see if you spot anything I may have missed, or got wrong... I have tested it a bit, and it appears to work the way it is intended to.

Let me know what you think! 😄