### PR TITLE
Add an id property to the separator for it to work properly with Sine.

### DIFF
--- a/preferences.json
+++ b/preferences.json
@@ -20,6 +20,7 @@
   {
     "type": "separator",
     "label": "Gemini",
+    "id": "gemini-separator",
     "conditions": [
       { "if": { "property": "extensions.tabgroups.ai_model", "value": 1 } }
     ]


### PR DESCRIPTION
Sine needs something as a reference id to be identified later (going to be fixed in a bit) so there is now an id property to identify items. I added the id property so that the separator will work with the conditions property even though it doesn't have a property property. (no better way to say that.)