### PR TITLE
Add Sort Tabs Context Menu with Preference Toggle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 api.txt
-test.mjs
+test.mjsCRUSH.md

--- a/preferences.json
+++ b/preferences.json
@@ -20,7 +20,8 @@
     "property": "extensions.tabgroups.enable_context_menu",
     "label": "Enable the sort tabs context menu item.",
     "type": "checkbox",
-    "defaultValue": true
+    "defaultValue": true,
+    "restart": true
     },
   {
     "property": "extensions.tabgroups.ai_model",

--- a/preferences.json
+++ b/preferences.json
@@ -16,6 +16,12 @@
     "type": "checkbox",
     "defaultValue": true
     },
+    {
+    "property": "extensions.tabgroups.enable_context_menu",
+    "label": "Enable the sort tabs context menu item.",
+    "type": "checkbox",
+    "defaultValue": true
+    },
   {
     "property": "extensions.tabgroups.ai_model",
     "label": "Choose AI - Gemini, Ollama, or Mistral",

--- a/tab_sort_clear.uc.js
+++ b/tab_sort_clear.uc.js
@@ -5,6 +5,7 @@
     // Feature toggle preference keys
     const ENABLE_SORT_PREF = "extensions.tabgroups.enable_sort";
     const ENABLE_CLEAR_PREF = "extensions.tabgroups.enable_clear";
+    const ENABLE_CONTEXT_MENU_PREF = "extensions.tabgroups.enable_context_menu";
     // Preference Key for AI Model Selection
     const AI_MODEL_PREF = "extensions.tabgroups.ai_model"; // '1' for Gemini, '2' for Ollama, '3' for Mistral
     // Preference Keys for AI Config
@@ -38,6 +39,7 @@
     // Read preference values
     const ENABLE_SORT_VALUE = getPref(ENABLE_SORT_PREF, true);
     const ENABLE_CLEAR_VALUE = getPref(ENABLE_CLEAR_PREF, true);
+    const ENABLE_CONTEXT_MENU_VALUE = getPref(ENABLE_CONTEXT_MENU_PREF, true);
     const AI_MODEL_VALUE = getPref(AI_MODEL_PREF, "1"); // Default to Gemini
     const OLLAMA_ENDPOINT_VALUE = getPref(OLLAMA_ENDPOINT_PREF, "http://localhost:11434/api/generate");
     const OLLAMA_MODEL_VALUE = getPref(OLLAMA_MODEL_PREF, "llama3.2");
@@ -49,7 +51,8 @@
     const CONFIG = {
         featureConfig: {
             sort: ENABLE_SORT_VALUE,
-            clear: ENABLE_CLEAR_VALUE
+            clear: ENABLE_CLEAR_VALUE,
+            contextMenu: ENABLE_CONTEXT_MENU_VALUE
         },
         apiConfig: {
             ollama: {
@@ -262,6 +265,17 @@
         @media not (-moz-bool-pref: "${ENABLE_CLEAR_PREF}") {
         
             #clear-button {
+            display: none;
+            }
+        }
+
+        @media not (-moz-bool-pref: "${ENABLE_CONTEXT_MENU_PREF}") {
+        
+            #context_zenSortTabs {
+            display: none;
+            }
+            
+            #context_zen-sort-tabs-separator {
             display: none;
             }
         }
@@ -1548,8 +1562,8 @@
                 
                 if (!menuItem || !separator) return;
 
-                // Check if sort feature is enabled
-                if (!CONFIG.featureConfig.sort) {
+                // Check if sort feature and context menu are enabled
+                if (!CONFIG.featureConfig.sort || !CONFIG.featureConfig.contextMenu) {
                     menuItem.setAttribute('hidden', 'true');
                     separator.setAttribute('hidden', 'true');
                     return;
@@ -1669,8 +1683,10 @@
         }
 
         // Setup context menu items and listeners
-        addContextMenuItem();
-        setupContextMenuListener();
+        if (CONFIG.featureConfig.contextMenu) {
+            addContextMenuItem();
+            setupContextMenuListener();
+        }
     }
 
 


### PR DESCRIPTION
## Summary

- Add "Sort Tabs" option to tab context menu when right-clicking
- Add independent preference toggle for context menu visibility
- Add automatic restart confirmation popup when toggling preference
- Context menu positioned before "Reload Tab" for logical grouping
- Smart visibility based on sort feature and workspace state
- Hides when multiple tabs selected (encourages button usage)

## Test plan

- [ ] Verify "Sort Tabs" appears in tab context menu when enabled
- [ ] Verify context menu item respects preference toggle setting
- [ ] Verify restart confirmation popup appears when toggling preference
- [ ] Test context menu functionality with single vs multiple tab selection
- [ ] Verify context menu hides when sort feature is disabled
- [ ] Test restart functionality from confirmation popup

## Implementation Details

- Uses Zen Browser's `MozXULElement.parseXULToFragment()` pattern
- Integrates with existing `cmd_zenSortTabs` command
- Adds CSS media queries for proper visibility control
- Follows Sine mod patterns for preference handling

💘 Generated with Crush CLI using GLM-4.6 to vibe code these features. Manual review is recommended as I'm not a programmer.